### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "optimist": "0.6.1",
     "q": "2.0.3",
     "quote": "0.4.0",
-    "request": "2.65.0",
+    "request": "2.74.0",
     "semver": "5.3.0",
     "update-notifier": "0.5.0"
   },


### PR DESCRIPTION
next-update currently has a vulnerable dependency, introducing 2 different types of known vulnerabilities.

[ReDOS vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722) in the `tough-cookie` dependency and [remote memory exposure](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.
You can see [Snyk test report](https://snyk.io/test/github/bahmutov/next-update) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, which uses the fixed `tough-cookie` version 2.3.1, and does not pull in any other vulnerable dependencies.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)